### PR TITLE
Streamline Molecular Mechanics

### DIFF
--- a/src/dp5/MacroModel.py
+++ b/src/dp5/MacroModel.py
@@ -17,7 +17,7 @@ import time
 import re
 
 
-def SetupMacroModel(settings):
+def SetupMM(settings):
     if settings.SCHRODINGER == '':
         SchrodEnv = os.getenv('SCHRODINGER')
         if SchrodEnv != None:
@@ -123,7 +123,7 @@ def SetupMacroModel(settings):
     return MacroModelInputs
 
 
-def RunMacroModel(MacroModelInputs, settings):
+def RunMM(MacroModelInputs, settings):
     # not args, but MacroModelInputs, numDS removed
     # Run Macromodel conformation search for all diastereomeric inputs
 

--- a/src/dp5/NWChem.py
+++ b/src/dp5/NWChem.py
@@ -356,7 +356,7 @@ def NMRSuffix(settings):
             (settings.nFunctional).lower() == 'm06-2x':
         suffix +=  'dft\n  xc m06-2x\n  mult 1\nend\n\n'
     elif (settings.nFunctional).lower() == 'mpw1pw91':
-        suffix += 'dft\n  xc mpw91 0.75 HFexch 0.25 perdew91\n  mult 1\nend\n\n'
+        suffix += 'dft\n  xc mpw91 perdew91\n  mult 1\nend\n\n'
     else:
         suffix += 'dft\n  xc ' + settings.nFunctional + '\n  mult 1\nend\n\n'
     suffix += 'task dft energy\n\nproperty\n  shielding\nend\ntask dft property\n'
@@ -372,7 +372,7 @@ def ESuffix(settings):
             (settings.nFunctional).lower() == 'm06-2x':
         suffix +=  'dft\n  xc m06-2x\n  mult 1\nend\n\n'
     elif (settings.nFunctional).lower() == 'mpw1pw91':
-        suffix += 'dft\n  xc mpw91 0.75 HFexch 0.25 perdew91\n  mult 1\nend\n\n'
+        suffix += 'dft\n  xc mpw91 perdew91\n  mult 1\nend\n\n'
     else:
         suffix += 'dft\n  xc ' + settings.nFunctional + '\n  mult 1\nend\n\n'
     suffix += 'task dft energy\n'

--- a/src/dp5/PyDP4.py
+++ b/src/dp5/PyDP4.py
@@ -36,8 +36,6 @@ Interprets the arguments and takes care of the general workflow logic.
 """
 
 from dp5 import NMR
-from dp5 import Tinker
-from dp5 import MacroModel
 from dp5 import DP5
 from dp5 import DP4
 

--- a/src/dp5/PyDP4.py
+++ b/src/dp5/PyDP4.py
@@ -47,8 +47,8 @@ import importlib
 import getpass
 from pathlib import Path
 
-DFTpackages = [['n', 'w', 'g', 'z', 'd'],['NWChem', 'NWChemZiggy', 'Gaussian', 'GaussianZiggy', 'GaussianDarwin']]
 MMpackages = [['m','t'],['Macromodel','Tinker']
+DFTpackages = [['n', 'w', 'g', 'z', 'd'],['NWChem', 'NWChemZiggy', 'Gaussian', 'GaussianZiggy', 'GaussianDarwin']]
 
 if os.name == 'nt':
     import pyximport

--- a/src/dp5/PyDP4.py
+++ b/src/dp5/PyDP4.py
@@ -50,6 +50,7 @@ import getpass
 from pathlib import Path
 
 DFTpackages = [['n', 'w', 'g', 'z', 'd'],['NWChem', 'NWChemZiggy', 'Gaussian', 'GaussianZiggy', 'GaussianDarwin']]
+MMpackages = [['m','t'],['Macromodel','Tinker']
 
 if os.name == 'nt':
     import pyximport
@@ -262,31 +263,17 @@ def main(settings):
 
     # Run conformational search, if requested
     if ('m' in settings.Workflow) and not (settings.AssumeDone or settings.UseExistingInputs):
-
-        #print("Performing conformational search using ", end="")
-
-        if settings.MM == 't':
-            print("Tinker")
-            print('\nSetting up Tinker files...')
-            TinkerInputs = Tinker.SetupTinker(settings)
-
-            print('\nRunning Tinker...')
-            TinkerOutputs = Tinker.RunTinker(TinkerInputs, settings)
-
-            Isomers = Tinker.ReadConformers(TinkerOutputs, Isomers, settings)
-
-        elif settings.MM == 'm':
-            print("MacroModel")
-            print('\nSetting up MacroModel files...')
-            MacroModelInputs = MacroModel.SetupMacroModel(settings)
-            print("MacroModel inputs: " + str(MacroModelInputs))
-            print('Running MacroModel...')
-            MacroModelOutputs = MacroModel.RunMacroModel(MacroModelInputs, settings)
-            print('\nReading conformers...')
-            Isomers = MacroModel.ReadConformers(MacroModelOutputs, Isomers, settings)
-            print('Energy window: ' + str(settings.MaxCutoffEnergy) + ' kJ/mol')
-            for iso in Isomers:
-                print(iso.InputFile + ": " + str(len(iso.Conformers)) + ' conformers read within energy window')
+        MM = ImportMM(settings.MM)
+        print("Performing conformational search")
+        print('\nSetting up files...')
+        MMInputs = MM.SetupMM(settings)
+        print('MM inputs: '+str(MMInputs))
+        print('Running MM:')
+        MMOutputs = MM.RunMM(MMInputs)
+        print('\nReading conformers...')
+        Isomers = MM.ReadConformers(MMOutputs, Isomers, settings)
+        for iso in Isomers:
+            print(iso.InputFile + ": " + str(len(iso.Conformers)) + ' conformers read within energy window')
     else:
         print('No conformational search was requested. Skipping...')
         settings.ConfPrune = False
@@ -546,6 +533,16 @@ def main(settings):
 
     return NMRData, Isomers, settings, DP4data, DP5data
 
+# Selects which MM package to import, returns imported module
+
+def ImportMM(mm):
+    if mm in MMpackages[0]:
+        MMindex = MMpackages[0].index(mm)
+        MM = importlib.import_module(f"dp5.{MMpackages[1][MMindex]}")
+    else:
+        print("Invalid MM package selected")
+        quit()
+    return MM
 
 # Selects which DFT package to import, returns imported module
 def ImportDFT(dft):
@@ -667,7 +664,7 @@ def run():
                                                  "s for computational and experimental NMR data extraction and stats analysis, default is 'gmns'",
                         default=settings.Workflow)
     parser.add_argument('-m', '--mm', help="Select molecular mechanics program,\
-    t for tinker or m for macromodel, default is m", choices=['t', 'm'],
+    t for tinker or m for macromodel, default is m", choices=MMpackages[0],
                         default='m')
     parser.add_argument('-d', '--dft', help="Select DFT program, \
     g for Gaussian, n for NWChem, z for Gaussian on ziggy, d for Gaussian on \

--- a/src/dp5/Tinker.py
+++ b/src/dp5/Tinker.py
@@ -18,7 +18,7 @@ from dp5 import PyDP4
 # Please modify the line below to give the path to the TINKER v8.x top level folder
 # This folder should contain bin/scan and params/mmff.prm for the process to work
 
-def SetupTinker(settings):
+def SetupMM(settings):
 
     TinkerInputs = []
     for inpfi in settings.InputFiles:
@@ -76,7 +76,7 @@ def SetupTinker(settings):
 
     return TinkerInputs
 
-def RunTinker(TinkerInputs, settings):
+def RunMM(TinkerInputs, settings):
     #Run Tinker scan for all diastereomeric inputs
     TinkerOutputs = []
     TinkerPrefix = os.path.join(settings.TinkerPath, 'bin', 'scan')


### PR DESCRIPTION
Minor refactoring of molecular mechanics packages. 

`dp5.Tinker` and `dp.5MacroModel` now have common `SetupMM` (ex `SetupTinker`, `SetupMacromodel`), `RunMM`(ex RunTinker, RunMacromodel), and `ReadConformers` methods. 

Removed explicit imports of `dp5.Tinker` and `dp5.Macromodel`, which are now imported using `ImportMM` function in `PyDP4.py` similar to `ImportDFT`.